### PR TITLE
AnswersRef from autoSave returning in the useConversationalForm

### DIFF
--- a/examples/src/Chatbot.tsx
+++ b/examples/src/Chatbot.tsx
@@ -95,10 +95,6 @@ const Chatbot: React.FC = () => {
 
   const autoSaveKey = 'test'
 
-  const answersRef = useRef<Answer[]>(
-    JSON.parse(localStorage.getItem(autoSaveKey) || '[]')
-  )
-
   const onInvalid = (
     instance: ConversationalForm,
     question: MutableRefObject<FlowDTO | undefined>,
@@ -140,7 +136,7 @@ const Chatbot: React.FC = () => {
     return true
   }
 
-  useConversationalForm({
+  const { answersRef } = useConversationalForm({
     validateAlreadyAnswered: {
       //questionVerificationTagId: 'email', // uncomment this line to use the validateQuestion method
       //validate: validateQuestion, // uncomment this line to use the validateQuestion method

--- a/src/components/chatbot/chatbot.ts
+++ b/src/components/chatbot/chatbot.ts
@@ -104,6 +104,7 @@ export type UseConversationalForm = {
   (options: Options): {
     cfInstance: MutableRefObject<ConversationalFormCf | undefined>
     currentQuestion: MutableRefObject<FlowDTO | undefined>
+    answersRef: MutableRefObject<Answer[]>
     startedAt: MutableRefObject<Date | undefined>
     finishedAt: MutableRefObject<Date | undefined>
     startBot: () => void
@@ -332,6 +333,7 @@ export const useConversationalForm: UseConversationalForm = ({
 
   return {
     cfInstance,
+    answersRef,
     currentQuestion,
     startBot,
     startedAt,


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request (em branco caso não tenha um específico)
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Criei testes relevantes para o meu código, ou determinei, em discussão com a equipe, que não há necessidade
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

---
- Retorna o AnswersRef do useChatbotAutoSave para pegar os valores atuais do chatbot (via localstorage).

### Screenshots (para mudanças visuais):

---

- Esse PR precisa de tasks scheduled/executadas pós-deploy:
  - *Listar tasks aqui, com uma breve descrição, caso existam*
